### PR TITLE
Host Header Handling

### DIFF
--- a/src/weighttp.c
+++ b/src/weighttp.c
@@ -159,7 +159,7 @@ static char *forge_request(char *url, char keep_alive, char **host, uint16_t *po
 			continue;
 		}
 		len += strlen(headers[i]) + strlen("\r\n");
-		if (strncmp(headers[i], "User-Agent: ", sizeof("User-Agent: ")-1) == 0)
+		if (strncmp(headers[i], "User-Agent:", sizeof("User-Agent:")-1) == 0)
 			have_user_agent = 1;
 	}
 


### PR DESCRIPTION
Fix for Bug #2477.

Also, as discussed in IRC, I've removed the requirement to have a space after the colon in the 'User-Agent' header.
