### PR TITLE
Add Linux TCP_FASTOPEN support through -f flag

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -118,10 +118,35 @@ static void client_reset(Client *client) {
 }
 
 static uint8_t client_connect(Client *client) {
+        int ret;
+        Config *config = client->worker->config;
+
 	//printf("connecting...\n");
 	start:
 
-	if (-1 == connect(client->sock_watcher.fd, client->worker->config->saddr->ai_addr, client->worker->config->saddr->ai_addrlen)) {
+	/*
+	 * If the user have enabled the TCP_FASTOPEN feature, start
+	 * communicating with sendto()
+	 */
+        if (config->linux_tcp_fastopen) {
+		ret = sendto(client->sock_watcher.fd, NULL, 0, MSG_FASTOPEN, client->worker->config->saddr->ai_addr, client->worker->config->saddr->ai_addrlen);
+		if (ret == -1 && errno == EOPNOTSUPP) {
+			printf("\nError: the server do not support TCP_FASTOPEN or the feature\n"
+			       "is disabled in the Kernel:\n\n"
+			       "  - Verify that your server is running at least Linux Kernel 3.7\n"
+			       "  - Verify that this machine is running at least Linux Kernel 3.6\n"
+			       "  - Check on both machines that TCP_FASTOPEN is enabled:\n\n"
+			       "       # cat /proc/sys/net/ipv4/tcp_fastopen\n\n"
+			       "    if the value is zero then enable it with:\n\n"
+			       "       # echo 1 > /proc/sys/net/ipv4/tcp_fastopen\n\n");
+			exit(EXIT_FAILURE);
+		}
+        }
+        else {
+		ret = connect(client->sock_watcher.fd, client->worker->config->saddr->ai_addr, client->worker->config->saddr->ai_addrlen);
+        }
+
+	if (ret == -1) {
 		switch (errno) {
 			case EINPROGRESS:
 			case EALREADY:
@@ -196,9 +221,10 @@ void client_state_machine(Client *client) {
 				goto start;
 			}
 		case CLIENT_WRITING:
-			while (1) {
-				r = write(client->sock_watcher.fd, &config->request[client->request_offset], config->request_size - client->request_offset);
+                        while (1) {
+                                r = write(client->sock_watcher.fd, &config->request[client->request_offset], config->request_size - client->request_offset);
 				//printf("write(%d - %d = %d): %d\n", config->request_size, client->request_offset, config->request_size - client->request_offset, r);
+
 				if (r == -1) {
 					/* error */
 					if (errno == EINTR)

--- a/src/client.h
+++ b/src/client.h
@@ -8,6 +8,12 @@
  *     MIT, see COPYING file
  */
 
+#include <sys/socket.h>
+
+#ifndef MSG_FASTOPEN
+#define MSG_FASTOPEN   0x20000000
+#endif
+
 struct Client {
 	enum {
 		CLIENT_START,

--- a/src/weighttp.c
+++ b/src/weighttp.c
@@ -14,12 +14,13 @@ extern int optind, optopt; /* getopt */
 
 static void show_help(void) {
 	printf("weighttp <options> <url>\n");
-	printf("  -n num   number of requests    (mandatory)\n");
-	printf("  -t num   threadcount           (default: 1)\n");
-	printf("  -c num   concurrent clients    (default: 1)\n");
-	printf("  -k       keep alive            (default: no)\n");
-	printf("  -6       use ipv6              (default: no)\n");
+	printf("  -n num   number of requests     (mandatory)\n");
+	printf("  -t num   threadcount            (default: 1)\n");
+	printf("  -c num   concurrent clients     (default: 1)\n");
+	printf("  -k       keep alive             (default: no)\n");
+	printf("  -6       use ipv6               (default: no)\n");
 	printf("  -H str   add header to request\n");
+	printf("  -f       use Linux TCP_FASTOPEN (default: no)\n");
 	printf("  -h       show help and exit\n");
 	printf("  -v       show version and exit\n\n");
 	printf("example: weighttpd -n 10000 -c 10 -t 2 -k -H \"User-Agent: foo\" localhost/index.html\n\n");
@@ -91,7 +92,7 @@ static char *forge_request(char *url, char keep_alive, char **host, uint16_t *po
 	len = strlen(url);
 
 	if ((c = strchr(url, ':'))) {
-		/* found ':' => host:port */ 
+		/* found ':' => host:port */
 		*host = W_MALLOC(char, c - url + 1);
 		memcpy(*host, url, c - url);
 		(*host)[c - url] = '\0';
@@ -219,8 +220,9 @@ int main(int argc, char *argv[]) {
 	config.concur_count = 1;
 	config.req_count = 0;
 	config.keep_alive = 0;
+	config.linux_tcp_fastopen = 0;
 
-	while ((c = getopt(argc, argv, ":hv6kn:t:c:H:")) != -1) {
+	while ((c = getopt(argc, argv, ":hv6kfn:t:c:H:")) != -1) {
 		switch (c) {
 			case 'h':
 				show_help();
@@ -248,6 +250,9 @@ int main(int argc, char *argv[]) {
 				headers = W_REALLOC(headers, char*, headers_num+1);
 				headers[headers_num] = optarg;
 				headers_num++;
+				break;
+			case 'f':
+				config.linux_tcp_fastopen = 1;
 				break;
 			case '?':
 				W_ERROR("unkown option: -%c", optopt);

--- a/src/weighttp.h
+++ b/src/weighttp.h
@@ -52,6 +52,7 @@ struct Config {
 	uint8_t thread_count;
 	uint16_t concur_count;
 	uint8_t keep_alive;
+	uint8_t linux_tcp_fastopen;
 
 	char *request;
 	uint32_t request_size;


### PR DESCRIPTION
Linux Kernels 3.6 and 3.7, introduces client and server support
for a new TCP featured called TCP_FASTOPEN. This feature reduces
the TCP handshake roundtrip improving performance for new
connections.

This patch implements this optional feature in weighttp through
the argument '-f'. If for some reason the system do not allow
a connection in this new mode, it will fail with the following
error message:
## 

Error: the server do not support TCP_FASTOPEN or the feature
is disabled in the Kernel:
- Verify that your server is running at least Linux Kernel 3.7
- Verify that this machine is running at least Linux Kernel 3.6
- Check on both machines that TCP_FASTOPEN is enabled:
  
     # cat /proc/sys/net/ipv4/tcp_fastopen
  
  if the value is zero then enable it with:
  ##    # echo 1 > /proc/sys/net/ipv4/tcp_fastopen

Signed-off-by: Eduardo Silva edsiper@gmail.com
