### PR TITLE
fix infinite loop on arm

### DIFF
--- a/src/weighttp.c
+++ b/src/weighttp.c
@@ -217,7 +217,7 @@ int main(int argc, char *argv[]) {
 	Worker **workers;
 	pthread_t *threads;
 	int i;
-	char c;
+	signed char c;
 	int err;
 	struct ev_loop *loop;
 	ev_tstamp ts_start, ts_end;


### PR DESCRIPTION
on arm, 'char' is unsigned by default; during option parsing, there is a
comparison between a char and -1, which always returns false, causing an
infinite loop. this patch declares the char variable as signed.
