### PR TITLE
Fix bug with chunked replies

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -427,9 +427,14 @@ static uint8_t client_parse(Client *client, int size) {
 				int consume_max;
 
 				str = &client->buffer[client->parser_offset];
-				/*printf("parsing chunk: '%s'\n(%"PRIi64" received, %"PRIi64" size, %d parser offset)\n",
-					str, client->chunk_received, client->chunk_size, client->parser_offset
+				/*printf("parsing chunk: '%s'\n(%"PRIi64" received, %"PRIi64" size, %d parser offset, %d size)\n",
+					str, client->chunk_received, client->chunk_size, client->parser_offset, size
 				);*/
+
+				// no more data, give back control to main loop
+				if (size == 0) {
+					return 1;
+				}
 
 				if (client->chunk_size == -1) {
 					/* read chunk size */

--- a/src/client.c
+++ b/src/client.c
@@ -431,11 +431,6 @@ static uint8_t client_parse(Client *client, int size) {
 					str, client->chunk_received, client->chunk_size, client->parser_offset, size
 				);*/
 
-				// no more data, give back control to main loop
-				if (size == 0) {
-					return 1;
-				}
-
 				if (client->chunk_size == -1) {
 					/* read chunk size */
 					client->chunk_size = 0;
@@ -453,6 +448,8 @@ static uint8_t client_parse(Client *client, int size) {
 							client->chunk_size += 10 + *str - 'A';
 						else if (*str >= 'a' && *str <= 'z')
 							client->chunk_size += 10 + *str - 'a';
+						else if (!str)
+							return (size > 64) ? 0 : 1; /* wait for more data, but only for a maximum line length of 64 */
 						else
 							return 0;
 					}


### PR DESCRIPTION
When server sends headers and then waits before sending response chunk,
`client_parse` returns error.

With this patch, control is given back to the event loop in order to wait for more data.