### PR TITLE
Support more than 64k concurrent clients

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -40,10 +40,11 @@ struct Client {
 	int64_t content_length;
 	uint64_t bytes_received; /* including http header */
 	uint16_t header_size;
+	struct sockaddr *src_addr;
 
 	char buffer[CLIENT_BUFFER_SIZE];
 };
 
-Client *client_new(Worker *worker);
+Client *client_new(Worker *worker, uint32_t id);
 void client_free(Client *client);
 void client_state_machine(Client *client);

--- a/src/weighttp.h
+++ b/src/weighttp.h
@@ -27,6 +27,7 @@
 #include <inttypes.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <arpa/inet.h>
 
 #include <ev.h>
 #include <pthread.h>
@@ -54,12 +55,14 @@ typedef struct Client Client;
 struct Config {
 	uint64_t req_count;
 	uint8_t thread_count;
-	uint16_t concur_count;
+	uint32_t concur_count;
 	uint8_t keep_alive;
 
 	char *request;
 	uint32_t request_size;
 	struct addrinfo *saddr;
+    uint8_t src_addr_count;
+    struct sockaddr_storage *src_addr;
 };
 
 uint64_t str_to_uint64(char *str);

--- a/src/worker.c
+++ b/src/worker.c
@@ -10,9 +10,9 @@
 
 #include "weighttp.h"
 
-Worker *worker_new(uint8_t id, Config *config, uint16_t num_clients, uint64_t num_requests) {
+Worker *worker_new(uint8_t id, Config *config, uint32_t num_clients, uint64_t num_requests) {
 	Worker *worker;
-	uint16_t i;
+	uint32_t i;
 
 	worker = W_MALLOC(Worker, 1);
 	worker->id = id;
@@ -29,7 +29,7 @@ Worker *worker_new(uint8_t id, Config *config, uint16_t num_clients, uint64_t nu
 	worker->clients = W_MALLOC(Client*, num_clients);
 
 	for (i = 0; i < num_clients; i++) {
-		if (NULL == (worker->clients[i] = client_new(worker)))
+		if (NULL == (worker->clients[i] = client_new(worker, i)))
 			return NULL;
 	}
 
@@ -37,7 +37,7 @@ Worker *worker_new(uint8_t id, Config *config, uint16_t num_clients, uint64_t nu
 }
 
 void worker_free(Worker *worker) {
-	uint16_t i;
+	uint32_t i;
 
 	for (i = 0; i < worker->num_clients; i++)
 		client_free(worker->clients[i]);
@@ -47,7 +47,7 @@ void worker_free(Worker *worker) {
 }
 
 void *worker_thread(void* arg) {
-	uint16_t i;
+	uint32_t i;
 	Worker *worker = (Worker*)arg;
 
 	/* start all clients */

--- a/src/worker.h
+++ b/src/worker.h
@@ -33,12 +33,12 @@ struct Worker {
 	struct ev_loop *loop;
 	char *request;
 	Client **clients;
-	uint16_t num_clients;
+	uint32_t num_clients;
 	Stats stats;
 	uint64_t progress_interval;
 };
 
 
-Worker *worker_new(uint8_t id, Config *config, uint16_t num_clients, uint64_t num_requests);
+Worker *worker_new(uint8_t id, Config *config, uint32_t num_clients, uint64_t num_requests);
 void worker_free(Worker *worker);
 void *worker_thread(void* arg);


### PR DESCRIPTION
The total number of TCP connections to a single destinatiation IP, port tuple
is limited to the hosts ephemeral TCP port range (on Linux
/proc/sys/net/ipv4/ip_local_port_range). To enable more concurrent connections
to a single destinatiation we can bind to multiple source addresses. This patch
permits this by introducing a -s argument which can be used to specify source
addresses for clients to use. Clients are distributed between the specified
source addresses. In addition this patch changes the type of the client count
variables from uint16_t to uint32_t to support more 65535 concurrent clients.

Signed-off-by: Dustin Lundquist <dustin@null-ptr.net>

Tested locally:
```
root@cp-dl02:~/weighttp/src# ./weighttp -n 180000 -c 180000 -s 172.24.4.254 -s 172.24.4.253 -s 172.24.4.252 -s 172.24.4.1 http://10.0.0.9/slow?delay=30s
weighttp 0.4 - a lightweight and simple webserver benchmarking tool

starting benchmark...
spawning thread #1: 180000 concurrent requests, 180000 total requests
progress:  10% done
progress:  20% done
progress:  30% done
progress:  40% done
progress:  50% done
progress:  60% done
progress:  70% done
progress:  80% done
progress:  90% done
progress: 100% done

finished in 67 sec, 606 millisec and 554 microsec, 2662 req/s, 434 kbyte/s
requests: 180000 total, 180000 started, 180000 done, 178202 succeeded, 1798 failed, 0 errored
status codes: 178202 2xx, 0 3xx, 0 4xx, 0 5xx
traffic: 30108546 bytes total, 28861132 bytes http, 1247414 bytes data
```